### PR TITLE
getPitch is using response wrapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/example/xharktankspringboot/controller/PitchController.java
+++ b/src/main/java/com/example/xharktankspringboot/controller/PitchController.java
@@ -1,5 +1,6 @@
 package com.example.xharktankspringboot.controller;
 
+import com.example.xharktankspringboot.domain.RestResponse;
 import com.example.xharktankspringboot.entity.CounterOffer;
 import com.example.xharktankspringboot.entity.Pitch;
 import com.example.xharktankspringboot.service.PitchService;
@@ -10,6 +11,8 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
+import static org.springframework.http.HttpStatus.*;
+
 @RestController
 @RequestMapping(path = "/api/v1/pitches")
 public class PitchController {
@@ -18,8 +21,20 @@ public class PitchController {
     private PitchService pitchService;
 
     @GetMapping("/{pitchId}")
-    private Optional<Pitch> getPitch(@PathVariable("pitchId") Long pitchId) {
-        return pitchService.getPitch(pitchId);
+    public RestResponse getPitch(@PathVariable("pitchId") Long pitchId) {
+        Optional<Pitch> pitch = pitchService.getPitch(pitchId);
+
+        if(!pitch.isPresent()) {
+            return RestResponse.builder()
+                    .statusCode(NOT_FOUND)
+                    .response("There is no pitch exists with provide id.")
+                    .build();
+        }
+
+        return RestResponse.builder()
+                .statusCode(OK)
+                .response(pitch.get())
+                .build();
     }
 
     @GetMapping("/")

--- a/src/main/java/com/example/xharktankspringboot/controller/PitchController.java
+++ b/src/main/java/com/example/xharktankspringboot/controller/PitchController.java
@@ -1,8 +1,8 @@
 package com.example.xharktankspringboot.controller;
 
+import com.example.xharktankspringboot.domain.RestResponse;
 import com.example.xharktankspringboot.dto.ResponseDTO;
 import com.example.xharktankspringboot.dto.ResponseDTOUtil;
-import com.example.xharktankspringboot.domain.RestResponse;
 import com.example.xharktankspringboot.entity.CounterOffer;
 import com.example.xharktankspringboot.entity.Pitch;
 import com.example.xharktankspringboot.service.PitchService;
@@ -17,7 +17,8 @@ import javax.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 
-import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
 
 @RestController
 @RequestMapping(path = "/api/v1/pitches")

--- a/src/main/java/com/example/xharktankspringboot/domain/RestResponse.java
+++ b/src/main/java/com/example/xharktankspringboot/domain/RestResponse.java
@@ -1,0 +1,12 @@
+package com.example.xharktankspringboot.domain;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@Builder
+public class RestResponse {
+    private HttpStatus statusCode;
+    private Object response;
+}

--- a/src/main/java/com/example/xharktankspringboot/exception/handler/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/com/example/xharktankspringboot/exception/handler/RestResponseEntityExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.example.xharktankspringboot.exception.handler;
+
+import com.example.xharktankspringboot.domain.RestResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+@ControllerAdvice(annotations = RestController.class)
+public class RestResponseEntityExceptionHandler {
+
+    @ExceptionHandler({ RuntimeException.class })
+    public ResponseEntity<RestResponse> handleRuntimeException(RuntimeException ex) {
+        RestResponse response = RestResponse.builder()
+                .statusCode(INTERNAL_SERVER_ERROR)
+                .response("There is some internal system error. Kindly contact system administrator.")
+                .build();
+
+        return new ResponseEntity(response, INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/com/example/xharktankspringboot/controller/PitchControllerTest.java
+++ b/src/test/java/com/example/xharktankspringboot/controller/PitchControllerTest.java
@@ -1,0 +1,56 @@
+package com.example.xharktankspringboot.controller;
+
+import com.example.xharktankspringboot.domain.RestResponse;
+import com.example.xharktankspringboot.entity.Pitch;
+import com.example.xharktankspringboot.service.PitchService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.*;
+
+@ExtendWith(MockitoExtension.class)
+class PitchControllerTest {
+    @Mock
+    private PitchService pitchService;
+
+    @InjectMocks
+    private PitchController pitchController;
+
+    @Test
+    public void shouldReturnSuccessResponseWithPitch() {
+        //Given
+        when(pitchService.getPitch(any())).thenReturn(Optional.of(new Pitch()));
+
+        //When
+        RestResponse response = pitchController.getPitch(1L);
+
+        //Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getResponse()).isInstanceOf(Pitch.class);
+    }
+
+    @Test
+    public void shouldReturnNotFoundResponseWithoutPitch() {
+        //Given
+        when(pitchService.getPitch(any())).thenReturn(Optional.empty());
+
+        //When
+        RestResponse response = pitchController.getPitch(1L);
+
+        //Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getResponse()).isInstanceOf(String.class);
+        assertThat(response.getResponse()).isEqualTo("There is no pitch exists with provide id.");
+    }
+
+}

--- a/src/test/java/com/example/xharktankspringboot/controller/PitchControllerTest.java
+++ b/src/test/java/com/example/xharktankspringboot/controller/PitchControllerTest.java
@@ -1,5 +1,6 @@
 package com.example.xharktankspringboot.controller;
 
+import com.example.xharktankspringboot.domain.RestResponse;
 import com.example.xharktankspringboot.entity.Pitch;
 import com.example.xharktankspringboot.service.PitchService;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +13,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Collections;
+import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -51,5 +57,34 @@ class PitchControllerTest {
         mockMvc.perform(get(ROOT_PATH))
                 .andDo(print())
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void shouldReturnSuccessResponseWithPitch() {
+        //Given
+        when(pitchService.getPitch(any())).thenReturn(Optional.of(new Pitch()));
+
+        //When
+        RestResponse response = pitchController.getPitch(1L);
+
+        //Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(OK);
+        assertThat(response.getResponse()).isInstanceOf(Pitch.class);
+    }
+
+    @Test
+    public void shouldReturnNotFoundResponseWithoutPitch() {
+        //Given
+        when(pitchService.getPitch(any())).thenReturn(Optional.empty());
+
+        //When
+        RestResponse response = pitchController.getPitch(1L);
+
+        //Then
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(NOT_FOUND);
+        assertThat(response.getResponse()).isInstanceOf(String.class);
+        assertThat(response.getResponse()).isEqualTo("There is no pitch exists with provide id.");
     }
 }


### PR DESCRIPTION
#2 In this PR

1. `RestResponseEntityExceptionHandler` introduced to handle general `RuntimeException` which can used to handle other application exceptions in future.
2. `RestResponse` wrapper around response
3. unit tests added for `PitchController`